### PR TITLE
update regex pattern to match ChromeDriver source

### DIFF
--- a/src/Concerns/DetectsChromeVersion.php
+++ b/src/Concerns/DetectsChromeVersion.php
@@ -114,7 +114,7 @@ trait DetectsChromeVersion
     {
         $home = file_get_contents($this->homeUrl);
 
-        preg_match('/Latest stable release:.*?\?path=([\d.]+)/', $home, $matches);
+        preg_match('/chromedriver.storage.googleapis.com\/index.html\?path=([\d.]+)/', $home, $matches);
 
         return $matches[1];
     }


### PR DESCRIPTION
```
PHP Fatal error:  Uncaught TypeError: Return value of Orchestra\DuskUpdater\UpdateCommand::latestVersion() must be of the type string, null returned in /Users/stevethomas/Code/Lp/lp-web/vendor/orchestra/dusk-updater/src/Concerns/DetectsChromeVersion.php:119
```

It seems the ChromeDriver website no longer matching the regex pattern `/Latest stable release:.*?\?path=([\d.]+)/`.

![image](https://user-images.githubusercontent.com/1127412/64670928-1ac29780-d4aa-11e9-98bc-e0ff9703f90d.png)

I reworked it to something I think will be more reliable.