### PR TITLE
PHP8 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "ext-openssl": "*",
         "ext-zip": "*",
-        "composer/semver": "^1.5",
+        "composer/semver": "^1.5 || ^3.0",
         "symfony/console": "^4.0 || ^5.0",
         "symfony/process": "^4.2 || ^5.0",
         "symfony/polyfill-ctype": "^1.9"


### PR DESCRIPTION
As we are working on getting Laravel working on PHP 8, we need this package updated as well - due to its used in Livewire.

We need Dusk tagged https://github.com/laravel/dusk/pull/831 but this can be merged as its not breaking anything. 

